### PR TITLE
Change psa_get() to clear the requested signal

### DIFF
--- a/TESTS/spm/neg_server_tests/neg_ipc_tests.cpp
+++ b/TESTS/spm/neg_server_tests/neg_ipc_tests.cpp
@@ -115,6 +115,14 @@ void server_get_signum_not_active()
     TEST_FAIL_MESSAGE("server_get_signum_not_active negative test failed at client side");
 }
 
+//Testing server get signum flag twice
+void server_get_signum_twice()
+{
+    psa_connect( PART2_GET_SIGNUM_TWICE, MINOR_VER);
+
+    TEST_FAIL_MESSAGE("server_get_signum_twice negative test failed at client side");
+}
+
 //Testing server read handle does not exist on the platform
 void server_read_invalid_handle()
 {
@@ -323,6 +331,7 @@ PSA_NEG_TEST(server_get_msg_null)
 PSA_NEG_TEST(server_get_multiple_bit_signum)
 PSA_NEG_TEST(server_get_signum_not_subset)
 PSA_NEG_TEST(server_get_signum_not_active)
+PSA_NEG_TEST(server_get_signum_twice)
 PSA_NEG_TEST(server_read_invalid_handle)
 PSA_NEG_TEST(server_read_null_handle)
 PSA_NEG_TEST(server_write_null_buffer)
@@ -341,8 +350,6 @@ PSA_NEG_TEST(server_read_on_wraparound_msg_ptr)
 PSA_NEG_TEST(server_read_from_excese_invec)
 PSA_NEG_TEST(server_write_on_wraparound_msg_ptr)
 PSA_NEG_TEST(server_write_from_excese_outvec)
-
-
 
 utest::v1::status_t spm_case_setup(const Case *const source, const size_t index_of_case)
 {
@@ -366,6 +373,7 @@ Case cases[] = {
     SPM_UTEST_CASE("Testing server get signum have more than one bit ON", server_get_multiple_bit_signum),
     SPM_UTEST_CASE("Testing server get signum flag is not a subset of current partition flags", server_get_signum_not_subset),
     SPM_UTEST_CASE("Testing server get signum flag is not active", server_get_signum_not_active),
+    SPM_UTEST_CASE("Testing server get signum twice", server_get_signum_twice),
     SPM_UTEST_CASE("Testing server read handle does not exist on the platform", server_read_invalid_handle),
     SPM_UTEST_CASE("Testing server read handle is PSA_NULL_HANDLE", server_read_null_handle),
     SPM_UTEST_CASE("Testing server write buffer is NULL", server_write_null_buffer),

--- a/TESTS/spm/neg_server_tests/part2_psa.json
+++ b/TESTS/spm/neg_server_tests/part2_psa.json
@@ -47,8 +47,16 @@
       "minor_policy": "relaxed"
     },
     {
-      "name": "PART2_READ_INVALID_HANDLE",
+      "name": "PART2_GET_SIGNUM_TWICE",
       "identifier": "0x00001A10",
+      "signal": "PART2_GET_SIGNUM_TWICE_MSK",
+      "non_secure_clients": true,
+      "minor_version": 5,
+      "minor_policy": "relaxed"
+    },
+    {
+      "name": "PART2_READ_INVALID_HANDLE",
+      "identifier": "0x00001A11",
       "signal": "PART2_READ_INVALID_HANDLE_MSK",
       "non_secure_clients": true,
       "minor_version": 5,
@@ -56,7 +64,7 @@
     },
     {
       "name": "PART2_READ_NULL_HANDLE",
-      "identifier": "0x00001A11",
+      "identifier": "0x00001A12",
       "signal": "PART2_READ_NULL_HANDLE_MSK",
       "non_secure_clients": true,
       "minor_version": 5,
@@ -64,7 +72,7 @@
     },
     {
       "name": "PART2_READ_TX_SIZE_ZERO",
-      "identifier": "0x00001A12",
+      "identifier": "0x00001A13",
       "signal": "PART2_READ_TX_SIZE_ZERO_MSK",
       "non_secure_clients": true,
       "minor_version": 5,
@@ -72,7 +80,7 @@
     },
     {
       "name": "PART2_WRITE_BUFFER_NULL",
-      "identifier": "0x00001A13",
+      "identifier": "0x00001A14",
       "signal": "PART2_WRITE_BUFFER_NULL_MSK",
       "non_secure_clients": true,
       "minor_version": 5,
@@ -80,7 +88,7 @@
     },
     {
       "name": "PART2_WRITE_RX_BUFF_NULL",
-      "identifier": "0x00001A14",
+      "identifier": "0x00001A15",
       "signal": "PART2_WRITE_RX_BUFF_NULL_MSK",
       "non_secure_clients": true,
       "minor_version": 5,
@@ -88,7 +96,7 @@
     },
     {
       "name": "PART2_WRITE_INVALID_HANDLE",
-      "identifier": "0x00001A15",
+      "identifier": "0x00001A16",
       "signal": "PART2_WRITE_INVALID_HANDLE_MSK",
       "non_secure_clients": true,
       "minor_version": 5,
@@ -96,7 +104,7 @@
     },
     {
       "name": "PART2_WRITE_NULL_HANDLE",
-      "identifier": "0x00001A16",
+      "identifier": "0x00001A17",
       "signal": "PART2_WRITE_NULL_HANDLE_MSK",
       "non_secure_clients": true,
       "minor_version": 5,
@@ -104,7 +112,7 @@
     },
     {
       "name": "PART2_END_INVALID_HANDLE",
-      "identifier": "0x00001A17",
+      "identifier": "0x00001A18",
       "signal": "PART2_END_INVALID_HANDLE_MSK",
       "non_secure_clients": true,
       "minor_version": 5,
@@ -112,7 +120,7 @@
     },
     {
       "name": "PART2_END_NULL_HANDLE",
-      "identifier": "0x00001A18",
+      "identifier": "0x00001A19",
       "signal": "PART2_END_NULL_HANDLE_MSK",
       "non_secure_clients": true,
       "minor_version": 5,
@@ -120,7 +128,7 @@
     },
     {
       "name": "PART2_SET_RHANDLE_INVALID",
-      "identifier": "0x00001A19",
+      "identifier": "0x00001A1A",
       "signal": "PART2_SET_RHANDLE_INVALID_MSK",
       "non_secure_clients": true,
       "minor_version": 5,
@@ -128,7 +136,7 @@
     },
     {
       "name": "PART2_NOTIFY_PART_ID_INVALID",
-      "identifier": "0x00001A1A",
+      "identifier": "0x00001A1B",
       "signal": "PART2_NOTIFY_PART_ID_INVALID_MSK",
       "non_secure_clients": true,
       "minor_version": 5,
@@ -136,7 +144,7 @@
     },
     {
       "name": "PART2_IDENTITY_INVALID_HANDLE",
-      "identifier": "0x00001A1B",
+      "identifier": "0x00001A1C",
       "signal": "PART2_IDENTITY_INVALID_HANDLE_MSK",
       "non_secure_clients": true,
       "minor_version": 5,
@@ -144,7 +152,7 @@
     },
     {
       "name": "PART2_IDENTITY_NULL_HANDLE",
-      "identifier": "0x00001A1C",
+      "identifier": "0x00001A1D",
       "signal": "PART2_IDENTITY_NULL_HANDLE_MSK",
       "non_secure_clients": true,
       "minor_version": 5,
@@ -152,7 +160,7 @@
     },
     {
       "name": "PART2_SET_RHANDLE_INVALID_HANDLE",
-      "identifier": "0x00001A1D",
+      "identifier": "0x00001A1E",
       "signal": "PART2_SET_RHANDLE_INVALID_HANDLE_MSK",
       "non_secure_clients": true,
       "minor_version": 5,
@@ -160,7 +168,7 @@
     },
     {
       "name": "PART2_SET_RHANDLE_NULL_HANDLE",
-      "identifier": "0x00001A1E",
+      "identifier": "0x00001A1F",
       "signal": "PART2_SET_RHANDLE_NULL_HANDLE_MSK",
       "non_secure_clients": true,
       "minor_version": 5,
@@ -168,7 +176,7 @@
     },
     {
       "name": "PART2_READ_WRAPAROUND",
-      "identifier": "0x00001A1F",
+      "identifier": "0x00001A20",
       "signal": "PART2_READ_WRAPAROUND_MSK",
       "non_secure_clients": true,
       "minor_version": 5,
@@ -176,7 +184,7 @@
     },
     {
       "name": "PART2_READ_EXCESE_INVEC",
-      "identifier": "0x00001A20",
+      "identifier": "0x00001A21",
       "signal": "PART2_READ_EXCESE_INVEC_MSK",
       "non_secure_clients": true,
       "minor_version": 5,
@@ -184,7 +192,7 @@
     },
     {
       "name": "PART2_WRITE_WRAPAROUND",
-      "identifier": "0x00001A21",
+      "identifier": "0x00001A22",
       "signal": "PART2_WRITE_WRAPAROUND_MSK",
       "non_secure_clients": true,
       "minor_version": 5,
@@ -192,7 +200,7 @@
     },
     {
       "name": "PART2_WRITE_EXCESE_OUTVEC",
-      "identifier": "0x00001A22",
+      "identifier": "0x00001A23",
       "signal": "PART2_WRITE_EXCESE_OUTVEC_MSK",
       "non_secure_clients": true,
       "minor_version": 5,

--- a/TESTS/spm/neg_server_tests/server2.c
+++ b/TESTS/spm/neg_server_tests/server2.c
@@ -61,6 +61,11 @@ void server_main2(void *ptr)
             psa_get(PART2_GET_MSG_NULL_MSK, &msg);      //send wrong flag
             TEST_FAIL_MESSAGE("server_get_signum_not_active negative test failed");
         }
+        else if (signals & PART2_GET_SIGNUM_TWICE_MSK) {
+            psa_get(PART2_GET_SIGNUM_TWICE_MSK, &msg);
+            psa_get(PART2_GET_SIGNUM_TWICE_MSK, &msg);
+            TEST_FAIL_MESSAGE("server_get_signum_twice negative test failed");
+        }
         else if (signals & PART2_READ_INVALID_HANDLE_MSK) {
             psa_get(PART2_READ_INVALID_HANDLE_MSK, &msg);
             switch (msg.type) {

--- a/TESTS/spm/server/main.cpp
+++ b/TESTS/spm/server/main.cpp
@@ -83,19 +83,6 @@ PSA_TEST_CLIENT(identity_during_close)
     TEST_ASSERT_EQUAL(PSA_SUCCESS, status);
 }
 
-PSA_TEST_CLIENT(get_msg_twice)
-{
-    psa_error_t status = PSA_SUCCESS;
-    psa_handle_t test_handle = psa_connect(TEST, TEST_SF_MINOR);
-    TEST_ASSERT(test_handle > 0);
-
-    status = psa_call(test_handle, NULL, 0, NULL, 0);
-    TEST_ASSERT_EQUAL(PSA_SUCCESS, status);
-
-    status = psa_close(test_handle);
-    TEST_ASSERT_EQUAL(PSA_SUCCESS, status);
-}
-
 PSA_TEST_CLIENT(msg_size_assertion)
 {
     psa_error_t status = PSA_SUCCESS;
@@ -299,7 +286,6 @@ Case cases[] = {
     SPM_UTEST_CASE("Get identity during connect", identity_during_connect),
     SPM_UTEST_CASE("Get identity during call", identity_during_call),
     SPM_UTEST_CASE("Get identity during disconnect", identity_during_close),
-    SPM_UTEST_CASE("Read message twice and compare", get_msg_twice),
     SPM_UTEST_CASE("Assert msg size", msg_size_assertion),
     SPM_UTEST_CASE("Reject on connect", reject_connection),
     SPM_UTEST_CASE("Read at an out of bound offset", read_at_outofboud_offset),

--- a/TESTS/spm/server/tests.c
+++ b/TESTS/spm/server/tests.c
@@ -189,44 +189,6 @@ PSA_TEST_SERVER(identity_during_close)
     return test_status;
 }
 
-PSA_TEST_SERVER(get_msg_twice)  //NO OUTPUT
-{
-    psa_error_t test_status = PSA_SUCCESS;
-    psa_error_t disconnect_status = PSA_SUCCESS;
-    psa_msg_t msg1 = {0};
-    psa_msg_t msg2 = {0};
-    uint32_t signals = 0;
-
-    test_status = proccess_connect_request();
-    if (test_status != PSA_SUCCESS) {
-        return test_status;
-    }
-
-    signals = psa_wait_any(PSA_WAIT_BLOCK);
-    if ((signals & TEST_MSK) == 0) {
-        test_status = PSA_GENERIC_ERROR;
-    }
-
-    psa_get(TEST_MSK, &msg1);
-    if (msg1.type != PSA_IPC_MSG_TYPE_CALL) {
-        test_status = ((test_status != PSA_SUCCESS) ? test_status : PSA_GENERIC_ERROR);
-    }
-
-    psa_get(TEST_MSK, &msg2);
-    if (msg2.type != PSA_IPC_MSG_TYPE_CALL) {
-        test_status = ((test_status != PSA_SUCCESS) ? test_status : PSA_GENERIC_ERROR);
-    }
-
-    *status_ptr = (memcmp(&msg1, &msg2, sizeof(msg1)) == 0) ? PSA_SUCCESS : PSA_GENERIC_ERROR;
-
-    psa_end(msg1.handle, PSA_SUCCESS);
-
-    disconnect_status = proccess_disconnect_request();
-    test_status  = (test_status != PSA_SUCCESS) ? test_status : disconnect_status;
-
-    return test_status;
-}
-
 PSA_TEST_SERVER(msg_size_assertion)
 {
     psa_error_t test_status = PSA_SUCCESS;
@@ -745,7 +707,6 @@ psa_test_server_side_func test_list[] = {
     PSA_TEST_SERVER_NAME(identity_during_connect),
     PSA_TEST_SERVER_NAME(identity_during_call),
     PSA_TEST_SERVER_NAME(identity_during_close),
-    PSA_TEST_SERVER_NAME(get_msg_twice),
     PSA_TEST_SERVER_NAME(msg_size_assertion),
     PSA_TEST_SERVER_NAME(reject_connection),
     PSA_TEST_SERVER_NAME(read_at_outofboud_offset),

--- a/spm/spm_server.c
+++ b/spm/spm_server.c
@@ -135,6 +135,10 @@ void psa_get(psa_signal_t signum, psa_msg_t *msg)
         SPM_PANIC("flag is not active!\n");
     }
 
+    int32_t flags = (int32_t)osThreadFlagsClear(signum);
+    SPM_ASSERT(flags >= 0);
+    PSA_UNUSED(flags);
+
     active_msg_t *active_msg = &(curr_partition->active_msg);
     SPM_ASSERT((active_msg->type > PSA_IPC_MSG_TYPE_INVALID) &&
                (active_msg->type <= PSA_IPC_MSG_TYPE_MAX));
@@ -276,10 +280,6 @@ void psa_end(psa_handle_t msg_handle, psa_error_t retval)
     SPM_ASSERT(NULL != curr_partition);        // active thread in SPM must be in partition DB
     spm_msg_handle_destroy(curr_partition->msg_handle);
     curr_partition->msg_handle = PSA_NULL_HANDLE;
-
-    int32_t flags = (int32_t)osThreadFlagsClear(dst_sec_func->mask);
-    SPM_ASSERT(flags >= 0);
-    PSA_UNUSED(flags);
 
     osStatus_t os_status = osSemaphoreRelease(dst_sec_func->partition->semaphore);
     SPM_ASSERT(osOK == os_status);


### PR DESCRIPTION
According to the psa_get() description in the latest spec:

> Each message can only be retrieved once.

Therefore signal cleaning has been moved from psa_end() to psa_get().

Also positive get_msg_twice twice test was removed and
instead negative server_get_signum_twice test was added.