### PR TITLE
Coverity fixes

### DIFF
--- a/TESTS/secure_time/library_api/secure_time_provisioning_partition.c
+++ b/TESTS/secure_time/library_api/secure_time_provisioning_partition.c
@@ -1,5 +1,4 @@
 #include "spm_server.h"
-#include "spm_client.h"
 #include "spm_panic.h"
 #include "psa_secure_time_test_provisioning_partition.h"
 #include "secure_time_client_spe.h"
@@ -24,6 +23,7 @@ void secure_time_provisioning_main(void *ptr)
             case PSA_IPC_MSG_TYPE_CALL:
                 switch (signals) {
                     case TEST_SET_PUBLIC_KEY_MSK:
+                    {
                         // ca_pubkey, ca_pubkey_size
                         if (msg.in_size[0] == 0) {
                             SPM_PANIC("Unknown parameters\n");
@@ -35,6 +35,7 @@ void secure_time_provisioning_main(void *ptr)
                         memset(key, 0, msg.in_size[0]);
                         free(key);
                         break;
+                    }
                     default:
                         SPM_PANIC("Unexpected signal %d (must be a programming error)!\n", signals);
                 }

--- a/secure_time/secure_time_client_proxy.c
+++ b/secure_time/secure_time_client_proxy.c
@@ -3,7 +3,6 @@
 #include "psa_secure_time_ifs.h"
 #include "secure_time_client_common.h"
 #include "secure_time_client.h"
-#include "secure_time_client_spe.h"
 
 int32_t secure_time_set_trusted_init(uint64_t *nonce)
 {


### PR DESCRIPTION
- Deliberately ignore secure_time_get_stored_time() return value
- Make sure when secure_time_get_stored_time() fails the read time value is set to 0